### PR TITLE
add cbor.null as possible drop-in replacement for lua "nil" values

### DIFF
--- a/cbor_c.c
+++ b/cbor_c.c
@@ -458,6 +458,10 @@ int luaopen_org_conman_cbor_c(lua_State *L)
   luaL_newlib(L,cbor_c_reg);
 #endif
   
+  /* pseudo-null cjson compatible value*/
+  lua_pushlightuserdata(L, NULL);
+  lua_setfield(L,-2,"null");
+
   lua_pushliteral(L,VERSION);
   lua_setfield(L,-2,"_VERSION");
   

--- a/test.lua
+++ b/test.lua
@@ -696,3 +696,10 @@ local q =
 
 test('_rains',"DA00E99BA8A100818204A3056F7777772E636F6E6D616E2E6F72672E0D81612E0E83010203"
         ,q,function() return cbor.TAG._rains(q) end)
+
+
+test('null',"F6",nil,function() return cbor.encode(cbor.null) end)
+
+cbor.safe_null_decode(true)
+test('null', 'F6', cbor.null)
+test('ARRAY', '82F6F6', { cbor.null, cbor.null })


### PR DESCRIPTION
Lua can't create array tables with trailing nil values, they are dropped away. So, you can't decode CBOR with such data without loosing information. Moreover, you can't encode such arrays at all. Special "cbor.null" value can be used in lua structures instead of "nil" to solve this problem, such structures are encoded as expected. Also you can decode CBOR with "cbor.null" instead of "nil" values when this mode is enabled.
This technique is implemented in lua-cjson package and works well. Value cbor.null is the same as cjson.null, so data extracted by one module can be used in other one directly and (I hope) without loosing data.